### PR TITLE
fix uuid update

### DIFF
--- a/lib/Service/SyncerService.php
+++ b/lib/Service/SyncerService.php
@@ -97,8 +97,8 @@ password = "${referencePassword}"
         $statusDir               = Application::$STATUS_DIR;
         $collectionNamePrincipal = "{$config->getCollection()}{$reference->getCollection()}";
         $collectionNameReference = "{$reference->getCollection()}{$config->getCollection()}";
-        $principalName           = Uuid::uuid1()->getHex();
-        $referenceName           = Uuid::uuid1()->getHex();
+        $principalName           = Uuid::uuid1()->getHex()->toString();
+        $referenceName           = Uuid::uuid1()->getHex()->toString();
 
         $content = str_replace('${pairName}', $pairName, $content);
         $content = str_replace('${statusDir}', $statusDir, $content);


### PR DESCRIPTION
fix error `str_replace(): Argument #2 ($replace) must be of type array|string, Ramsey\Uuid\Type\Hexadecimal given in file`

cause: https://uuid.ramsey.dev/_/downloads/en/stable/pdf/ --> page 38 --> new return types in version 4